### PR TITLE
fix: BotCommandScope marshalling

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -2,6 +2,7 @@ package echotron
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"io"
 	"os"
 	"reflect"
@@ -1474,14 +1475,45 @@ func TestReopenGeneralForumTopic(t *testing.T) {
 }
 
 func TestSetMyCommands(t *testing.T) {
-	_, err := api.SetMyCommands(
-		nil,
-		commands...,
-	)
-
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name string
+		opts *CommandOptions
+		cmds []BotCommand
+		//expect APIResponseBool
+		assertion   require.ErrorAssertionFunc
+		description string
+	}{
+		{
+			name:        "#1",
+			cmds:        commands,
+			assertion:   require.NoError,
+			description: "",
+		},
+		{
+			name: "#2 - with Scope",
+			opts: &CommandOptions{
+				LanguageCode: "ru",
+				Scope:        BotCommandScope{Type: BCSTChat, ChatID: chatID},
+			},
+			cmds:        commands,
+			assertion:   require.NoError,
+			description: "With Scope",
+		},
 	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := api.SetMyCommands(
+				tt.opts,
+				tt.cmds...,
+			)
+			if err != nil {
+				tt.assertion(t, err)
+				return
+			}
+		})
+	}
+
 }
 
 func TestGetMyCommands(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/NicoNex/echotron/v3
 
 go 1.19
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
+	github.com/stretchr/testify v1.8.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/querybuilder_test.go
+++ b/querybuilder_test.go
@@ -1,0 +1,56 @@
+package echotron
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScan(t *testing.T) {
+	tests := []struct {
+		name        string
+		i           any
+		val         url.Values
+		except      url.Values
+		description string
+	}{
+		{
+			name: "#1",
+			i: CommandOptions{
+				LanguageCode: "ru",
+				Scope:        BotCommandScope{Type: BCSTChat, ChatID: 33288},
+			},
+			val: url.Values{
+				"foo":   {"bar"},
+				"scope": {"{\"type\":\"chat\",\"chat_id\":33288,\"user_id\":0}"},
+			},
+			except: url.Values{
+				"foo":           {"bar"},
+				"language_code": {"ru"},
+				"scope":         {"{\"type\":\"chat\",\"chat_id\":33288,\"user_id\":0}"},
+			},
+			description: "Scopes doesn't serialized",
+		},
+		{
+			// TODO: i don't know what ist...
+			name: "#2",
+			i: CommandOptions{
+				Scope: BotCommandScope{Type: BCSTChat, ChatID: 0101010},
+			},
+			val: url.Values{
+				"scope": {"{\"type\":\"chat\",\"chat_id\":0101010,\"user_id\":0}"},
+			},
+			except: url.Values{
+				"scope": {"{\"type\":\"chat\",\"chat_id\":0101010,\"user_id\":0}"},
+			},
+			description: "Invalid ChatID",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := scan(tt.i, tt.val)
+			assert.Equal(t, tt.except, result, tt.description)
+		})
+	}
+}

--- a/types.go
+++ b/types.go
@@ -1023,9 +1023,9 @@ const (
 
 // BotCommandScope is an optional parameter used in the SetMyCommands, DeleteMyCommands and GetMyCommands methods.
 type BotCommandScope struct {
-	Type   BotCommandScopeType `query:"type"`
-	ChatID int64               `query:"chat_id"`
-	UserID int64               `query:"user_id"`
+	Type   BotCommandScopeType `query:"type" json:"type"`
+	ChatID int64               `query:"chat_id" json:"chat_id"`
+	UserID int64               `query:"user_id" json:"user_id"`
 }
 
 // PermissionOptions is a custom type used to allow proper serialization of ChatPermissions-type parameters in some methods.


### PR DESCRIPTION
bug: Nested **BotCommandScope** struct in **CommandOptions** doesn't serialized (converted to string with camelcase)
